### PR TITLE
feat(example): add start/stop toggle to looping animation demos

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -45,7 +45,7 @@ function ButtonDemo() {
 }
 
 function BannerDemo() {
-  const [playing, setPlaying] = useState(true);
+  const [playing, setPlaying] = useState(false);
   return (
     <Section title="Scrolling Banner">
       <View style={styles.bannerContainer}>
@@ -80,7 +80,7 @@ function BannerDemo() {
 }
 
 function PulseDemo() {
-  const [playing, setPlaying] = useState(true);
+  const [playing, setPlaying] = useState(false);
   return (
     <Section title="Pulse (Reverse Loop)">
       {playing && (


### PR DESCRIPTION
## Description

The example app has two demos with infinite looping animations (Scrolling Banner and Pulse) that prevent Android uiautomator from reaching idle state, breaking agent-device snapshot and accessibility-based automation tools. This adds start/stop controls to both demos.

## Solution

Each looping demo gets a playing state (default false) with a Start/Stop toggle button. When stopped, the EaseView is unmounted entirely, which cancels the native animation. Tapping Start mounts the component, starting the animation. Demos default to stopped so UI automation tools work immediately on app launch.

### iOS

![iOS demo](https://i.imgur.com/ewpwSXI.gif)

### Android

![Android demo](https://i.imgur.com/c4YHd2u.gif)

## Test plan

- Built and ran on iOS simulator (iPhone 17 Pro, iOS 26.2)
- Built and ran on Android device (Samsung Galaxy S21+)
- Verified demos start in stopped state (no looping animation on mount)
- Verified Start mounts the animated view and animation begins
- Verified Stop unmounts the view and cancels the animation
- All CI checks pass (lint, types, build-library, build-ios, build-android)