### PR TITLE
feat: add className prop to EaseView component and corresponding test

### DIFF
--- a/src/EaseView.tsx
+++ b/src/EaseView.tsx
@@ -86,6 +86,8 @@ export type EaseViewProps = ViewProps & {
   useHardwareLayer?: boolean;
   /** Pivot point for scale and rotation as 0–1 fractions. @default { x: 0.5, y: 0.5 } (center) */
   transformOrigin?: TransformOrigin;
+  /** NativeWind / Tailwind CSS class string. Requires NativeWind in your project. */
+  className?: string;
 };
 
 export function EaseView({

--- a/src/__tests__/EaseView.test.tsx
+++ b/src/__tests__/EaseView.test.tsx
@@ -258,6 +258,12 @@ describe('EaseView', () => {
       expect(screen.getByText('Hello')).toBeTruthy();
     });
 
+    it('passes className through', () => {
+      render(<EaseView testID="ease" className="bg-red-500 p-4" />);
+      const props = getNativeProps();
+      expect(props.className).toBe('bg-red-500 p-4');
+    });
+
     it('passes style through', () => {
       render(
         <EaseView


### PR DESCRIPTION
## Summary

Added `className` prop to `EaseView` for NativeWind compatibility.

### What changed

**`src/EaseView.tsx`** — Added `className?: string` to `EaseViewProps`. Since `className` is not destructured, it flows through `{...rest}` to the native view automatically. NativeWind's babel transform intercepts it before it reaches native.

**`src/__tests__/EaseView.test.tsx`** — Added test verifying `className` is forwarded as a prop.

### How it works

Users with NativeWind in their project can now use Tailwind classes on `EaseView`:

```tsx
<EaseView
  className="w-24 h-24 rounded-2xl bg-indigo-500"
  animate={{ scale: pressed ? 1.2 : 1 }}
  transition={{ type: 'spring', damping: 12 }}
/>
```

NativeWind's babel plugin transforms `className` into a `style` prop at build time — `EaseView` just needs to accept and forward it.
