### PR TITLE
fix(example): add web script and exclude benchmark on web

### DIFF
--- a/example/modules/frame-metrics/src/index.web.ts
+++ b/example/modules/frame-metrics/src/index.web.ts
@@ -1,0 +1,22 @@
+export type FrameMetricsResult = {
+  avgUiThreadTime: number;
+  p95UiThreadTime: number;
+  p99UiThreadTime: number;
+  avgAnimationTime?: number;
+  avgLayoutTime?: number;
+  avgDrawTime?: number;
+};
+
+export const isAndroid = false;
+
+export function startCollecting(): void {
+  // no-op on web
+}
+
+export function stopCollecting(): FrameMetricsResult {
+  return {
+    avgUiThreadTime: 0,
+    p95UiThreadTime: 0,
+    p99UiThreadTime: 0,
+  };
+}

--- a/example/package.json
+++ b/example/package.json
@@ -7,6 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "start": "expo start",
+    "web": "expo start --web",
     "prebuild": "expo prebuild",
     "build:android": "expo prebuild --platform android --clean && cd android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
     "build:ios": "expo prebuild --platform ios --clean && xcodebuild -workspace ios/EaseExample.xcworkspace -scheme EaseExample -configuration Debug -sdk iphonesimulator -arch x86_64 build"

--- a/example/src/demos/index.ts
+++ b/example/src/demos/index.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react';
+import { Platform } from 'react-native';
 
 import { BackgroundColorDemo } from './BackgroundColorDemo';
 import { BenchmarkDemo } from './BenchmarkDemo';
@@ -79,11 +80,15 @@ export const demos: Record<string, DemoEntry> = {
     title: 'Comparison',
     section: 'Advanced',
   },
-  'benchmark': {
-    component: BenchmarkDemo,
-    title: 'Benchmark',
-    section: 'Advanced',
-  },
+  ...(Platform.OS !== 'web'
+    ? {
+        benchmark: {
+          component: BenchmarkDemo,
+          title: 'Benchmark',
+          section: 'Advanced',
+        },
+      }
+    : {}),
 };
 
 interface SectionData {


### PR DESCRIPTION
## Summary
- Add `web` script to example (`expo start --web`)
- Exclude benchmark demo on web (uses native `FrameMetrics` module)

## Test plan
- [ ] Run `yarn example web` and verify the app loads without errors
- [ ] Verify benchmark demo does not appear in the demo list on web
- [ ] Verify benchmark demo still works on iOS/Android