### PR TITLE
feat: add animated borderWidth and borderColor

### DIFF
--- a/android/src/main/java/com/ease/EaseView.kt
+++ b/android/src/main/java/com/ease/EaseView.kt
@@ -14,6 +14,8 @@ import androidx.dynamicanimation.animation.DynamicAnimation
 import androidx.dynamicanimation.animation.SpringAnimation
 import androidx.dynamicanimation.animation.SpringForce
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.BackgroundStyleApplicator
+import com.facebook.react.uimanager.style.LogicalEdge
 import com.facebook.react.views.view.ReactViewGroup
 import kotlin.math.sqrt
 
@@ -34,7 +36,10 @@ class EaseView(context: Context) : ReactViewGroup(context) {
     private var prevRotateY: Float? = null
     private var prevBorderRadius: Float? = null
     private var prevBackgroundColor: Int? = null
+    private var prevBorderWidth: Float? = null
+    private var prevBorderColor: Int? = null
     private var currentBackgroundColor: Int = Color.TRANSPARENT
+    private var currentBorderColor: Int = Color.BLACK
 
     // --- First mount tracking ---
     private var isFirstMount: Boolean = true
@@ -59,7 +64,7 @@ class EaseView(context: Context) : ReactViewGroup(context) {
             return
         }
         val configs = mutableMapOf<String, TransitionConfig>()
-        val keys = listOf("defaultConfig", "transform", "opacity", "borderRadius", "backgroundColor")
+        val keys = listOf("defaultConfig", "transform", "opacity", "borderRadius", "backgroundColor", "border")
         for (key in keys) {
             if (map.hasKey(key)) {
                 val configMap = map.getMap(key) ?: continue
@@ -92,6 +97,7 @@ class EaseView(context: Context) : ReactViewGroup(context) {
             "rotate", "rotateX", "rotateY" -> "transform"
             "borderRadius" -> "borderRadius"
             "backgroundColor" -> "backgroundColor"
+            "borderWidth", "borderColor" -> "border"
             else -> null
         }
         if (categoryKey != null) {
@@ -103,7 +109,7 @@ class EaseView(context: Context) : ReactViewGroup(context) {
     private fun allTransitionsNone(): Boolean {
         val defaultConfig = transitionConfigs["defaultConfig"]
         if (defaultConfig == null || defaultConfig.type != "none") return false
-        val categories = listOf("transform", "opacity", "borderRadius", "backgroundColor")
+        val categories = listOf("transform", "opacity", "borderRadius", "backgroundColor", "border")
         return categories.all { key ->
             val config = transitionConfigs[key]
             config == null || config.type == "none"
@@ -122,6 +128,8 @@ class EaseView(context: Context) : ReactViewGroup(context) {
         const val MASK_ROTATE_Y = 1 shl 7
         const val MASK_BORDER_RADIUS = 1 shl 8
         const val MASK_BACKGROUND_COLOR = 1 shl 9
+        const val MASK_BORDER_WIDTH = 1 shl 10
+        const val MASK_BORDER_COLOR = 1 shl 11
     }
 
     // --- Transform origin (0–1 fractions) ---
@@ -155,6 +163,28 @@ class EaseView(context: Context) : ReactViewGroup(context) {
         }
     }
 
+    // --- Border width (animated via ObjectAnimator("animateBorderWidth")) ---
+    private var _borderWidth: Float = 0f
+
+    @Suppress("unused") // Used by ObjectAnimator via reflection
+    fun getAnimateBorderWidth(): Float = _borderWidth
+    @Suppress("unused") // Used by ObjectAnimator via reflection
+    fun setAnimateBorderWidth(value: Float) {
+        if (_borderWidth != value) {
+            _borderWidth = value
+            BackgroundStyleApplicator.setBorderWidth(this, LogicalEdge.ALL, value)
+        }
+    }
+
+    private fun applyBorderColor(color: Int) {
+        currentBorderColor = color
+        BackgroundStyleApplicator.setBorderColor(this, LogicalEdge.ALL, color)
+    }
+
+    private fun getCurrentBorderColor(): Int {
+        return currentBorderColor
+    }
+
     // --- Hardware layer ---
     var useHardwareLayer: Boolean = false
 
@@ -177,6 +207,8 @@ class EaseView(context: Context) : ReactViewGroup(context) {
     var initialAnimateRotateY: Float = 0.0f
     var initialAnimateBorderRadius: Float = 0.0f
     var initialAnimateBackgroundColor: Int = Color.TRANSPARENT
+    var initialAnimateBorderWidth: Float = 0.0f
+    var initialAnimateBorderColor: Int = Color.BLACK
 
     // --- Pending animate values (buffered per-view, applied in onAfterUpdateTransaction) ---
     var pendingOpacity: Float = 1.0f
@@ -189,6 +221,8 @@ class EaseView(context: Context) : ReactViewGroup(context) {
     var pendingRotateY: Float = 0.0f
     var pendingBorderRadius: Float = 0.0f
     var pendingBackgroundColor: Int = Color.TRANSPARENT
+    var pendingBorderWidth: Float = 0.0f
+    var pendingBorderColor: Int = Color.BLACK
 
     // --- Running animations ---
     private val runningAnimators = mutableMapOf<String, Animator>()
@@ -258,7 +292,7 @@ class EaseView(context: Context) : ReactViewGroup(context) {
     }
 
     fun applyPendingAnimateValues() {
-        applyAnimateValues(pendingOpacity, pendingTranslateX, pendingTranslateY, pendingScaleX, pendingScaleY, pendingRotate, pendingRotateX, pendingRotateY, pendingBorderRadius, pendingBackgroundColor)
+        applyAnimateValues(pendingOpacity, pendingTranslateX, pendingTranslateY, pendingScaleX, pendingScaleY, pendingRotate, pendingRotateX, pendingRotateY, pendingBorderRadius, pendingBackgroundColor, pendingBorderWidth, pendingBorderColor)
     }
 
     private fun applyAnimateValues(
@@ -271,7 +305,9 @@ class EaseView(context: Context) : ReactViewGroup(context) {
         rotateX: Float,
         rotateY: Float,
         borderRadius: Float,
-        backgroundColor: Int
+        backgroundColor: Int,
+        borderWidth: Float,
+        borderColor: Int
     ) {
         if (pendingBatchAnimationCount > 0) {
             onTransitionEnd?.invoke(false)
@@ -297,7 +333,9 @@ class EaseView(context: Context) : ReactViewGroup(context) {
                 (mask and MASK_ROTATE_X != 0 && initialAnimateRotateX != rotateX) ||
                 (mask and MASK_ROTATE_Y != 0 && initialAnimateRotateY != rotateY) ||
                 (mask and MASK_BORDER_RADIUS != 0 && initialAnimateBorderRadius != borderRadius) ||
-                (mask and MASK_BACKGROUND_COLOR != 0 && initialAnimateBackgroundColor != backgroundColor)
+                (mask and MASK_BACKGROUND_COLOR != 0 && initialAnimateBackgroundColor != backgroundColor) ||
+                (mask and MASK_BORDER_WIDTH != 0 && initialAnimateBorderWidth != borderWidth) ||
+                (mask and MASK_BORDER_COLOR != 0 && initialAnimateBorderColor != borderColor)
 
             if (hasInitialAnimation) {
                 // Set initial values for animated properties
@@ -311,6 +349,8 @@ class EaseView(context: Context) : ReactViewGroup(context) {
                 if (mask and MASK_ROTATE_Y != 0) this.rotationY = initialAnimateRotateY
                 if (mask and MASK_BORDER_RADIUS != 0) setAnimateBorderRadius(initialAnimateBorderRadius)
                 if (mask and MASK_BACKGROUND_COLOR != 0) applyBackgroundColor(initialAnimateBackgroundColor)
+                if (mask and MASK_BORDER_WIDTH != 0) setAnimateBorderWidth(initialAnimateBorderWidth)
+                if (mask and MASK_BORDER_COLOR != 0) applyBorderColor(initialAnimateBorderColor)
 
                 // Animate properties that differ from initial to target
                 if (mask and MASK_OPACITY != 0 && initialAnimateOpacity != opacity) {
@@ -343,6 +383,12 @@ class EaseView(context: Context) : ReactViewGroup(context) {
                 if (mask and MASK_BACKGROUND_COLOR != 0 && initialAnimateBackgroundColor != backgroundColor) {
                     animateBackgroundColor(initialAnimateBackgroundColor, backgroundColor, getTransitionConfig("backgroundColor"), loop = true)
                 }
+                if (mask and MASK_BORDER_WIDTH != 0 && initialAnimateBorderWidth != borderWidth) {
+                    animateProperty("animateBorderWidth", null, initialAnimateBorderWidth, borderWidth, getTransitionConfig("borderWidth"), loop = true)
+                }
+                if (mask and MASK_BORDER_COLOR != 0 && initialAnimateBorderColor != borderColor) {
+                    animateBorderColorTransition(initialAnimateBorderColor, borderColor, getTransitionConfig("borderColor"), loop = true)
+                }
 
                 // If all per-property configs were 'none', no animations were queued.
                 // Fire onTransitionEnd immediately to match the scalar 'none' contract.
@@ -361,6 +407,8 @@ class EaseView(context: Context) : ReactViewGroup(context) {
                 if (mask and MASK_ROTATE_Y != 0) this.rotationY = rotateY
                 if (mask and MASK_BORDER_RADIUS != 0) setAnimateBorderRadius(borderRadius)
                 if (mask and MASK_BACKGROUND_COLOR != 0) applyBackgroundColor(backgroundColor)
+                if (mask and MASK_BORDER_WIDTH != 0) setAnimateBorderWidth(borderWidth)
+                if (mask and MASK_BORDER_COLOR != 0) applyBorderColor(borderColor)
             }
 
             // Update backface visibility after setting initial rotation values.
@@ -381,6 +429,8 @@ class EaseView(context: Context) : ReactViewGroup(context) {
             if (mask and MASK_ROTATE_Y != 0) this.rotationY = rotateY
             if (mask and MASK_BORDER_RADIUS != 0) setAnimateBorderRadius(borderRadius)
             if (mask and MASK_BACKGROUND_COLOR != 0) applyBackgroundColor(backgroundColor)
+            if (mask and MASK_BORDER_WIDTH != 0) setAnimateBorderWidth(borderWidth)
+            if (mask and MASK_BORDER_COLOR != 0) applyBorderColor(borderColor)
             onTransitionEnd?.invoke(true)
         } else {
             // Subsequent updates: animate changed properties (skip non-animated)
@@ -523,6 +573,31 @@ class EaseView(context: Context) : ReactViewGroup(context) {
                 }
             }
 
+            if (prevBorderWidth != null && mask and MASK_BORDER_WIDTH != 0 && prevBorderWidth != borderWidth) {
+                anyPropertyChanged = true
+                val config = getTransitionConfig("borderWidth")
+                if (config.type == "none") {
+                    runningAnimators["animateBorderWidth"]?.cancel()
+                    runningAnimators.remove("animateBorderWidth")
+                    setAnimateBorderWidth(borderWidth)
+                } else {
+                    val from = getCurrentValue("animateBorderWidth")
+                    animateProperty("animateBorderWidth", null, from, borderWidth, config)
+                }
+            }
+
+            if (prevBorderColor != null && mask and MASK_BORDER_COLOR != 0 && prevBorderColor != borderColor) {
+                anyPropertyChanged = true
+                val config = getTransitionConfig("borderColor")
+                if (config.type == "none") {
+                    runningAnimators["borderColor"]?.cancel()
+                    runningAnimators.remove("borderColor")
+                    applyBorderColor(borderColor)
+                } else {
+                    animateBorderColorTransition(getCurrentBorderColor(), borderColor, config)
+                }
+            }
+
             // If all changed properties resolved to 'none', no animations were queued.
             // Fire onTransitionEnd immediately.
             if (anyPropertyChanged && pendingBatchAnimationCount == 0) {
@@ -540,6 +615,8 @@ class EaseView(context: Context) : ReactViewGroup(context) {
         prevRotateY = rotateY
         prevBorderRadius = borderRadius
         prevBackgroundColor = backgroundColor
+        prevBorderWidth = borderWidth
+        prevBorderColor = borderColor
     }
 
     private fun getCurrentValue(propertyName: String): Float = when (propertyName) {
@@ -552,6 +629,7 @@ class EaseView(context: Context) : ReactViewGroup(context) {
         "rotationX" -> this.rotationX
         "rotationY" -> this.rotationY
         "animateBorderRadius" -> getAnimateBorderRadius()
+        "animateBorderWidth" -> getAnimateBorderWidth()
         else -> 0f
     }
 
@@ -607,6 +685,52 @@ class EaseView(context: Context) : ReactViewGroup(context) {
         }
 
         runningAnimators["backgroundColor"] = animator
+        animator.start()
+    }
+
+    private fun animateBorderColorTransition(fromColor: Int, toColor: Int, config: TransitionConfig, loop: Boolean = false) {
+        runningAnimators["borderColor"]?.cancel()
+
+        val batchId = animationBatchId
+        pendingBatchAnimationCount++
+
+        val animator = ValueAnimator.ofArgb(fromColor, toColor).apply {
+            duration = config.duration.toLong()
+            startDelay = config.delay
+
+            interpolator = PathInterpolator(
+                config.easingBezier[0], config.easingBezier[1],
+                config.easingBezier[2], config.easingBezier[3]
+            )
+            if (loop && config.loop != "none") {
+                repeatCount = ValueAnimator.INFINITE
+                repeatMode = if (config.loop == "reverse") ValueAnimator.REVERSE else ValueAnimator.RESTART
+            }
+            addUpdateListener { animation ->
+                val color = animation.animatedValue as Int
+                this@EaseView.currentBorderColor = color
+                BackgroundStyleApplicator.setBorderColor(this@EaseView, LogicalEdge.ALL, color)
+            }
+            addListener(object : AnimatorListenerAdapter() {
+                private var cancelled = false
+                override fun onAnimationStart(animation: Animator) {
+                    this@EaseView.onEaseAnimationStart()
+                }
+                override fun onAnimationCancel(animation: Animator) { cancelled = true }
+                override fun onAnimationEnd(animation: Animator) {
+                    this@EaseView.onEaseAnimationEnd()
+                    if (batchId == animationBatchId) {
+                        if (cancelled) anyInterrupted = true
+                        pendingBatchAnimationCount--
+                        if (pendingBatchAnimationCount <= 0) {
+                            onTransitionEnd?.invoke(!anyInterrupted)
+                        }
+                    }
+                }
+            })
+        }
+
+        runningAnimators["borderColor"] = animator
         animator.start()
     }
 
@@ -837,6 +961,8 @@ class EaseView(context: Context) : ReactViewGroup(context) {
         prevRotateY = null
         prevBorderRadius = null
         prevBackgroundColor = null
+        prevBorderWidth = null
+        prevBorderColor = null
 
         this.alpha = 1f
         this.translationX = 0f
@@ -848,6 +974,8 @@ class EaseView(context: Context) : ReactViewGroup(context) {
         this.rotationY = 0f
         setAnimateBorderRadius(0f)
         applyBackgroundColor(Color.TRANSPARENT)
+        setAnimateBorderWidth(0f)
+        applyBorderColor(Color.BLACK)
 
         transformPerspective = 1280f
         isFirstMount = true

--- a/android/src/main/java/com/ease/EaseView.kt
+++ b/android/src/main/java/com/ease/EaseView.kt
@@ -707,9 +707,7 @@ class EaseView(context: Context) : ReactViewGroup(context) {
                 repeatMode = if (config.loop == "reverse") ValueAnimator.REVERSE else ValueAnimator.RESTART
             }
             addUpdateListener { animation ->
-                val color = animation.animatedValue as Int
-                this@EaseView.currentBorderColor = color
-                BackgroundStyleApplicator.setBorderColor(this@EaseView, LogicalEdge.ALL, color)
+                this@EaseView.applyBorderColor(animation.animatedValue as Int)
             }
             addListener(object : AnimatorListenerAdapter() {
                 private var cancelled = false

--- a/android/src/main/java/com/ease/EaseViewManager.kt
+++ b/android/src/main/java/com/ease/EaseViewManager.kt
@@ -153,6 +153,30 @@ class EaseViewManager : ReactViewManager() {
         view.initialAnimateBackgroundColor = value ?: Color.TRANSPARENT
     }
 
+    // --- Border width ---
+
+    @ReactProp(name = "animateBorderWidth", defaultFloat = 0f)
+    fun setAnimateBorderWidth(view: EaseView, value: Float) {
+        view.pendingBorderWidth = PixelUtil.toPixelFromDIP(value)
+    }
+
+    @ReactProp(name = "initialAnimateBorderWidth", defaultFloat = 0f)
+    fun setInitialAnimateBorderWidth(view: EaseView, value: Float) {
+        view.initialAnimateBorderWidth = PixelUtil.toPixelFromDIP(value)
+    }
+
+    // --- Border color ---
+
+    @ReactProp(name = "animateBorderColor", customType = "Color")
+    fun setAnimateBorderColor(view: EaseView, value: Int?) {
+        view.pendingBorderColor = value ?: Color.BLACK
+    }
+
+    @ReactProp(name = "initialAnimateBorderColor", customType = "Color")
+    fun setInitialAnimateBorderColor(view: EaseView, value: Int?) {
+        view.initialAnimateBorderColor = value ?: Color.BLACK
+    }
+
     // --- Hardware layer ---
 
     @ReactProp(name = "useHardwareLayer", defaultBoolean = false)

--- a/android/src/main/java/com/ease/EaseViewManager.kt
+++ b/android/src/main/java/com/ease/EaseViewManager.kt
@@ -157,12 +157,13 @@ class EaseViewManager : ReactViewManager() {
 
     @ReactProp(name = "animateBorderWidth", defaultFloat = 0f)
     fun setAnimateBorderWidth(view: EaseView, value: Float) {
-        view.pendingBorderWidth = PixelUtil.toPixelFromDIP(value)
+        // BackgroundStyleApplicator.setBorderWidth expects DIPs (converts internally)
+        view.pendingBorderWidth = value
     }
 
     @ReactProp(name = "initialAnimateBorderWidth", defaultFloat = 0f)
     fun setInitialAnimateBorderWidth(view: EaseView, value: Float) {
-        view.initialAnimateBorderWidth = PixelUtil.toPixelFromDIP(value)
+        view.initialAnimateBorderWidth = value
     }
 
     // --- Border color ---

--- a/example/src/demos/BorderDemo.tsx
+++ b/example/src/demos/BorderDemo.tsx
@@ -5,25 +5,34 @@ import { EaseView } from 'react-native-ease';
 import { Section } from '../components/Section';
 import { Button } from '../components/Button';
 
+const states = [
+  { borderWidth: 0, borderColor: '#4a90d9', label: 'None' },
+  { borderWidth: 4, borderColor: '#e74c3c', label: 'Red' },
+  { borderWidth: 4, borderColor: '#4ade80', label: 'Green' },
+] as const;
+
+const nextLabel = ['Add Red', 'Go Green', 'Remove'] as const;
+
 export function BorderDemo() {
-  const [active, setActive] = useState(false);
+  const [index, setIndex] = useState(0);
+  const state = states[index]!;
   return (
     <Section title="Border">
       <EaseView
         animate={{
-          borderWidth: active ? 4 : 0,
-          borderColor: active ? '#e74c3c' : '#4a90d9',
+          borderWidth: state.borderWidth,
+          borderColor: state.borderColor,
         }}
         transition={{
           border: { type: 'spring', damping: 15, stiffness: 120 },
         }}
         style={styles.box}
       >
-        <Text style={styles.text}>{active ? 'Red' : 'None'}</Text>
+        <Text style={styles.text}>{state.label}</Text>
       </EaseView>
       <Button
-        label={active ? 'Remove' : 'Add Border'}
-        onPress={() => setActive((v) => !v)}
+        label={nextLabel[index]!}
+        onPress={() => setIndex((i) => (i + 1) % states.length)}
       />
     </Section>
   );

--- a/example/src/demos/BorderDemo.tsx
+++ b/example/src/demos/BorderDemo.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { Text, StyleSheet } from 'react-native';
+import { EaseView } from 'react-native-ease';
+
+import { Section } from '../components/Section';
+import { Button } from '../components/Button';
+
+export function BorderDemo() {
+  const [active, setActive] = useState(false);
+  return (
+    <Section title="Border">
+      <EaseView
+        animate={{
+          borderWidth: active ? 4 : 0,
+          borderColor: active ? '#e74c3c' : '#4a90d9',
+        }}
+        transition={{
+          border: { type: 'spring', damping: 15, stiffness: 120 },
+        }}
+        style={styles.box}
+      >
+        <Text style={styles.text}>{active ? 'Red' : 'None'}</Text>
+      </EaseView>
+      <Button
+        label={active ? 'Remove' : 'Add Border'}
+        onPress={() => setActive((v) => !v)}
+      />
+    </Section>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: {
+    width: 100,
+    height: 100,
+    borderRadius: 16,
+    backgroundColor: '#f0f0f0',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: '#333',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+});

--- a/example/src/demos/index.ts
+++ b/example/src/demos/index.ts
@@ -5,6 +5,7 @@ import { BackgroundColorDemo } from './BackgroundColorDemo';
 import { BenchmarkDemo } from './BenchmarkDemo';
 import { BannerDemo } from './BannerDemo';
 import { CardFlipDemo } from './CardFlipDemo';
+import { BorderDemo } from './BorderDemo';
 import { BorderRadiusDemo } from './BorderRadiusDemo';
 import { ButtonDemo } from './ButtonDemo';
 import { CombinedDemo } from './CombinedDemo';
@@ -60,6 +61,11 @@ export const demos: Record<string, DemoEntry> = {
   'styled-card': {
     component: StyledCardDemo,
     title: 'Styled Card',
+    section: 'Style',
+  },
+  'border': {
+    component: BorderDemo,
+    title: 'Border',
     section: 'Style',
   },
   'border-radius': {

--- a/ios/EaseView.mm
+++ b/ios/EaseView.mm
@@ -28,6 +28,8 @@ static NSString *const kAnimKeyTransformTransX = @"ease_transform_trX";
 static NSString *const kAnimKeyTransformTransY = @"ease_transform_trY";
 static NSString *const kAnimKeyCornerRadius = @"ease_cornerRadius";
 static NSString *const kAnimKeyBackgroundColor = @"ease_backgroundColor";
+static NSString *const kAnimKeyBorderWidth = @"ease_borderWidth";
+static NSString *const kAnimKeyBorderColor = @"ease_borderColor";
 
 static inline CGFloat degreesToRadians(CGFloat degrees) {
   return degrees * M_PI / 180.0;
@@ -62,6 +64,8 @@ static const int kMaskRotateX = 1 << 6;
 static const int kMaskRotateY = 1 << 7;
 static const int kMaskBorderRadius = 1 << 8;
 static const int kMaskBackgroundColor = 1 << 9;
+static const int kMaskBorderWidth = 1 << 10;
+static const int kMaskBorderColor = 1 << 11;
 static const int kMaskAnyTransform = kMaskTranslateX | kMaskTranslateY |
                                      kMaskScaleX | kMaskScaleY | kMaskRotate |
                                      kMaskRotateX | kMaskRotateY;
@@ -128,6 +132,9 @@ transitionConfigForProperty(const std::string &name,
     return transitionConfigFromStruct(t.borderRadius);
   } else if (name == "backgroundColor" && hasConfig(t.backgroundColor)) {
     return transitionConfigFromStruct(t.backgroundColor);
+  } else if ((name == "borderWidth" || name == "borderColor") &&
+             hasConfig(t.border)) {
+    return transitionConfigFromStruct(t.border);
   }
   // Fallback to defaultConfig
   return transitionConfigFromStruct(t.defaultConfig);
@@ -342,6 +349,14 @@ static std::string lowestTransformPropertyName(int mask) {
                                    viewProps.initialAnimateBackgroundColor !=
                                        viewProps.animateBackgroundColor;
 
+  BOOL hasInitialBorderWidth =
+      (mask & kMaskBorderWidth) &&
+      viewProps.initialAnimateBorderWidth != viewProps.animateBorderWidth;
+
+  BOOL hasInitialBorderColor =
+      (mask & kMaskBorderColor) &&
+      viewProps.initialAnimateBorderColor != viewProps.animateBorderColor;
+
   BOOL hasInitialTransform = NO;
   CATransform3D initialT = CATransform3DIdentity;
   CATransform3D targetT = CATransform3DIdentity;
@@ -371,7 +386,8 @@ static std::string lowestTransformPropertyName(int mask) {
   }
 
   if (hasInitialOpacity || hasInitialTransform || hasInitialBorderRadius ||
-      hasInitialBackgroundColor) {
+      hasInitialBackgroundColor || hasInitialBorderWidth ||
+      hasInitialBorderColor) {
     // Set initial values after props and layout have settled for this mount.
     if (mask & kMaskOpacity)
       self.layer.opacity = viewProps.initialAnimateOpacity;
@@ -385,6 +401,12 @@ static std::string lowestTransformPropertyName(int mask) {
     if (mask & kMaskBackgroundColor)
       self.layer.backgroundColor =
           RCTUIColorFromSharedColor(viewProps.initialAnimateBackgroundColor)
+              .CGColor;
+    if (mask & kMaskBorderWidth)
+      self.layer.borderWidth = viewProps.initialAnimateBorderWidth;
+    if (mask & kMaskBorderColor)
+      self.layer.borderColor =
+          RCTUIColorFromSharedColor(viewProps.initialAnimateBorderColor)
               .CGColor;
 
     // Animate from initial to target (skip if config is 'none')
@@ -507,6 +529,37 @@ static std::string lowestTransformPropertyName(int mask) {
                                   loop:YES];
       }
     }
+    if (hasInitialBorderWidth) {
+      EaseTransitionConfig config =
+          transitionConfigForProperty("borderWidth", viewProps);
+      self.layer.borderWidth = viewProps.animateBorderWidth;
+      if (config.type != "none") {
+        [self applyAnimationForKeyPath:@"borderWidth"
+                          animationKey:kAnimKeyBorderWidth
+                             fromValue:@(viewProps.initialAnimateBorderWidth)
+                               toValue:@(viewProps.animateBorderWidth)
+                                config:config
+                                  loop:YES];
+      }
+    }
+    if (hasInitialBorderColor) {
+      EaseTransitionConfig config =
+          transitionConfigForProperty("borderColor", viewProps);
+      self.layer.borderColor =
+          RCTUIColorFromSharedColor(viewProps.animateBorderColor).CGColor;
+      if (config.type != "none") {
+        [self applyAnimationForKeyPath:@"borderColor"
+                          animationKey:kAnimKeyBorderColor
+                             fromValue:(__bridge id)RCTUIColorFromSharedColor(
+                                           viewProps.initialAnimateBorderColor)
+                                           .CGColor
+                               toValue:(__bridge id)RCTUIColorFromSharedColor(
+                                           viewProps.animateBorderColor)
+                                           .CGColor
+                                config:config
+                                  loop:YES];
+      }
+    }
 
     // If all per-property configs were 'none', no animations were queued.
     // Fire onTransitionEnd immediately to match the scalar 'none' contract.
@@ -530,6 +583,11 @@ static std::string lowestTransformPropertyName(int mask) {
     if (mask & kMaskBackgroundColor)
       self.layer.backgroundColor =
           RCTUIColorFromSharedColor(viewProps.animateBackgroundColor).CGColor;
+    if (mask & kMaskBorderWidth)
+      self.layer.borderWidth = viewProps.animateBorderWidth;
+    if (mask & kMaskBorderColor)
+      self.layer.borderColor =
+          RCTUIColorFromSharedColor(viewProps.animateBorderColor).CGColor;
   }
 }
 
@@ -593,7 +651,9 @@ static std::string lowestTransformPropertyName(int mask) {
              (!hasConfig(newViewProps.transitions.borderRadius) ||
               newViewProps.transitions.borderRadius.type == "none") &&
              (!hasConfig(newViewProps.transitions.backgroundColor) ||
-              newViewProps.transitions.backgroundColor.type == "none")) {
+              newViewProps.transitions.backgroundColor.type == "none") &&
+             (!hasConfig(newViewProps.transitions.border) ||
+              newViewProps.transitions.border.type == "none")) {
     // All transitions are 'none' — set values immediately
     [self beginAnimationBatch];
     [self.layer removeAllAnimations];
@@ -609,6 +669,11 @@ static std::string lowestTransformPropertyName(int mask) {
       self.layer.backgroundColor =
           RCTUIColorFromSharedColor(newViewProps.animateBackgroundColor)
               .CGColor;
+    if (mask & kMaskBorderWidth)
+      self.layer.borderWidth = newViewProps.animateBorderWidth;
+    if (mask & kMaskBorderColor)
+      self.layer.borderColor =
+          RCTUIColorFromSharedColor(newViewProps.animateBorderColor).CGColor;
     if (_eventEmitter) {
       auto emitter =
           std::static_pointer_cast<const EaseViewEventEmitter>(_eventEmitter);
@@ -822,6 +887,47 @@ static std::string lowestTransformPropertyName(int mask) {
       }
     }
 
+    if ((mask & kMaskBorderWidth) &&
+        oldViewProps.animateBorderWidth != newViewProps.animateBorderWidth) {
+      anyPropertyChanged = YES;
+      EaseTransitionConfig config =
+          transitionConfigForProperty("borderWidth", newViewProps);
+      self.layer.borderWidth = newViewProps.animateBorderWidth;
+      if (config.type == "none") {
+        [self.layer removeAnimationForKey:kAnimKeyBorderWidth];
+      } else {
+        [self applyAnimationForKeyPath:@"borderWidth"
+                          animationKey:kAnimKeyBorderWidth
+                             fromValue:[self presentationValueForKeyPath:
+                                                 @"borderWidth"]
+                               toValue:@(newViewProps.animateBorderWidth)
+                                config:config
+                                  loop:NO];
+      }
+    }
+
+    if ((mask & kMaskBorderColor) &&
+        oldViewProps.animateBorderColor != newViewProps.animateBorderColor) {
+      anyPropertyChanged = YES;
+      EaseTransitionConfig config =
+          transitionConfigForProperty("borderColor", newViewProps);
+      CGColorRef toColor =
+          RCTUIColorFromSharedColor(newViewProps.animateBorderColor).CGColor;
+      self.layer.borderColor = toColor;
+      if (config.type == "none") {
+        [self.layer removeAnimationForKey:kAnimKeyBorderColor];
+      } else {
+        CGColorRef fromColor = (__bridge CGColorRef)
+            [self presentationValueForKeyPath:@"borderColor"];
+        [self applyAnimationForKeyPath:@"borderColor"
+                          animationKey:kAnimKeyBorderColor
+                             fromValue:(__bridge id)fromColor
+                               toValue:(__bridge id)toColor
+                                config:config
+                                  loop:NO];
+      }
+    }
+
     // If all changed properties resolved to 'none', no animations were queued.
     // Fire onTransitionEnd immediately.
     if (anyPropertyChanged && _pendingAnimationCount == 0 && _eventEmitter) {
@@ -857,7 +963,8 @@ static std::string lowestTransformPropertyName(int mask) {
       *std::static_pointer_cast<const EaseViewProps>(_props);
   int mask = viewProps.animatedProperties;
 
-  if (!(mask & (kMaskOpacity | kMaskBorderRadius | kMaskBackgroundColor))) {
+  if (!(mask & (kMaskOpacity | kMaskBorderRadius | kMaskBackgroundColor |
+                kMaskBorderWidth | kMaskBorderColor))) {
     return;
   }
 
@@ -876,6 +983,15 @@ static std::string lowestTransformPropertyName(int mask) {
     [self.layer removeAnimationForKey:@"backgroundColor"];
     self.layer.backgroundColor =
         RCTUIColorFromSharedColor(viewProps.animateBackgroundColor).CGColor;
+  }
+  if (mask & kMaskBorderWidth) {
+    [self.layer removeAnimationForKey:kAnimKeyBorderWidth];
+    self.layer.borderWidth = viewProps.animateBorderWidth;
+  }
+  if (mask & kMaskBorderColor) {
+    [self.layer removeAnimationForKey:kAnimKeyBorderColor];
+    self.layer.borderColor =
+        RCTUIColorFromSharedColor(viewProps.animateBorderColor).CGColor;
   }
   [CATransaction commit];
 }
@@ -917,6 +1033,8 @@ static std::string lowestTransformPropertyName(int mask) {
   self.layer.cornerRadius = 0;
   self.layer.masksToBounds = NO;
   self.layer.backgroundColor = nil;
+  self.layer.borderWidth = 0;
+  self.layer.borderColor = nil;
 }
 
 @end

--- a/src/EaseView.tsx
+++ b/src/EaseView.tsx
@@ -21,6 +21,7 @@ const IDENTITY = {
   rotateX: 0,
   rotateY: 0,
   borderRadius: 0,
+  borderWidth: 0,
 };
 
 /** Bitmask flags — must match native constants. */
@@ -35,6 +36,8 @@ const MASK_ROTATE_X = 1 << 6;
 const MASK_ROTATE_Y = 1 << 7;
 const MASK_BORDER_RADIUS = 1 << 8;
 const MASK_BACKGROUND_COLOR = 1 << 9;
+const MASK_BORDER_WIDTH = 1 << 10;
+const MASK_BORDER_COLOR = 1 << 11;
 /* eslint-enable no-bitwise */
 
 /** Maps animate prop keys to style keys that conflict. */
@@ -50,6 +53,8 @@ const ANIMATE_TO_STYLE_KEYS: Record<keyof AnimateProps, string> = {
   rotateY: 'transform',
   borderRadius: 'borderRadius',
   backgroundColor: 'backgroundColor',
+  borderWidth: 'borderWidth',
+  borderColor: 'borderColor',
 };
 
 /** Preset easing curves as cubic bezier control points. */
@@ -137,6 +142,7 @@ const CATEGORY_KEYS = [
   'opacity',
   'borderRadius',
   'backgroundColor',
+  'border',
 ] as const;
 
 /** Resolve the transition prop into a NativeTransitions struct. */
@@ -241,6 +247,8 @@ export function EaseView({
   if (animate?.borderRadius != null) animatedProperties |= MASK_BORDER_RADIUS;
   if (animate?.backgroundColor != null)
     animatedProperties |= MASK_BACKGROUND_COLOR;
+  if (animate?.borderWidth != null) animatedProperties |= MASK_BORDER_WIDTH;
+  if (animate?.borderColor != null) animatedProperties |= MASK_BORDER_COLOR;
   /* eslint-enable no-bitwise */
 
   // Resolve animate values (identity defaults for non-animated — safe values).
@@ -267,9 +275,11 @@ export function EaseView({
     rotateY: initial?.rotateY ?? IDENTITY.rotateY,
   };
 
-  // Resolve backgroundColor — passed as ColorValue directly (codegen handles conversion)
+  // Resolve color props — passed as ColorValue directly (codegen handles conversion)
   const animBgColor = animate?.backgroundColor ?? 'transparent';
   const initialBgColor = initialAnimate?.backgroundColor ?? animBgColor;
+  const animBorderColor = animate?.borderColor ?? 'black';
+  const initialBorderColor = initialAnimate?.borderColor ?? animBorderColor;
 
   // Strip style keys that conflict with animated properties
   let cleanStyle: ViewProps['style'] = style;
@@ -328,6 +338,8 @@ export function EaseView({
       animateRotateY={resolved.rotateY}
       animateBorderRadius={resolved.borderRadius}
       animateBackgroundColor={animBgColor}
+      animateBorderWidth={resolved.borderWidth}
+      animateBorderColor={animBorderColor}
       initialAnimateOpacity={resolvedInitial.opacity}
       initialAnimateTranslateX={resolvedInitial.translateX}
       initialAnimateTranslateY={resolvedInitial.translateY}
@@ -338,6 +350,8 @@ export function EaseView({
       initialAnimateRotateY={resolvedInitial.rotateY}
       initialAnimateBorderRadius={resolvedInitial.borderRadius}
       initialAnimateBackgroundColor={initialBgColor}
+      initialAnimateBorderWidth={resolvedInitial.borderWidth}
+      initialAnimateBorderColor={initialBorderColor}
       transitions={transitions}
       useHardwareLayer={useHardwareLayer}
       transformOriginX={transformOrigin?.x ?? 0.5}

--- a/src/EaseView.web.tsx
+++ b/src/EaseView.web.tsx
@@ -201,6 +201,8 @@ const CSS_PROP_MAP = {
   transform: 'transform',
   borderRadius: 'border-radius',
   backgroundColor: 'background-color',
+  borderWidth: 'border-width',
+  borderColor: 'border-color',
 } as const;
 
 type CategoryKey = keyof typeof CSS_PROP_MAP;
@@ -216,6 +218,8 @@ function resolvePerCategoryConfigs(
       transform: def,
       borderRadius: def,
       backgroundColor: def,
+      borderWidth: def,
+      borderColor: def,
     };
   }
   if (isSingleTransition(transition)) {
@@ -225,10 +229,15 @@ function resolvePerCategoryConfigs(
       transform: def,
       borderRadius: def,
       backgroundColor: def,
+      borderWidth: def,
+      borderColor: def,
     };
   }
   // TransitionMap
   const defaultConfig = resolveConfigForCss(transition.default);
+  const borderConfig = transition.border
+    ? resolveConfigForCss(transition.border)
+    : defaultConfig;
   return {
     opacity: transition.opacity
       ? resolveConfigForCss(transition.opacity)
@@ -242,6 +251,8 @@ function resolvePerCategoryConfigs(
     backgroundColor: transition.backgroundColor
       ? resolveConfigForCss(transition.backgroundColor)
       : defaultConfig,
+    borderWidth: borderConfig,
+    borderColor: borderConfig,
   };
 }
 
@@ -489,6 +500,12 @@ export function EaseView({
       : {}),
     ...(displayValues.backgroundColor
       ? { backgroundColor: displayValues.backgroundColor }
+      : {}),
+    ...(displayValues.borderWidth > 0
+      ? { borderWidth: displayValues.borderWidth }
+      : {}),
+    ...(displayValues.borderColor
+      ? { borderColor: displayValues.borderColor }
       : {}),
   };
 

--- a/src/EaseView.web.tsx
+++ b/src/EaseView.web.tsx
@@ -11,7 +11,9 @@ import type {
 } from './types';
 
 /** Identity values used as defaults for animate/initialAnimate. */
-const IDENTITY: Required<Omit<AnimateProps, 'scale' | 'backgroundColor'>> = {
+const IDENTITY: Required<
+  Omit<AnimateProps, 'scale' | 'backgroundColor' | 'borderColor'>
+> = {
   opacity: 1,
   translateX: 0,
   translateY: 0,
@@ -21,6 +23,7 @@ const IDENTITY: Required<Omit<AnimateProps, 'scale' | 'backgroundColor'>> = {
   rotateX: 0,
   rotateY: 0,
   borderRadius: 0,
+  borderWidth: 0,
 };
 
 /** Preset easing curves as cubic bezier control points. */
@@ -124,9 +127,10 @@ export type EaseViewProps = {
 };
 
 function resolveAnimateValues(props: AnimateProps | undefined): Required<
-  Omit<AnimateProps, 'scale' | 'backgroundColor'>
+  Omit<AnimateProps, 'scale' | 'backgroundColor' | 'borderColor'>
 > & {
   backgroundColor?: string;
+  borderColor?: string;
 } {
   return {
     ...IDENTITY,
@@ -136,6 +140,7 @@ function resolveAnimateValues(props: AnimateProps | undefined): Required<
     rotateX: props?.rotateX ?? IDENTITY.rotateX,
     rotateY: props?.rotateY ?? IDENTITY.rotateY,
     backgroundColor: props?.backgroundColor as string | undefined,
+    borderColor: props?.borderColor as string | undefined,
   };
 }
 

--- a/src/EaseViewNativeComponent.ts
+++ b/src/EaseViewNativeComponent.ts
@@ -26,6 +26,7 @@ type NativeTransitions = Readonly<{
   opacity?: NativeTransitionConfig;
   borderRadius?: NativeTransitionConfig;
   backgroundColor?: NativeTransitionConfig;
+  border?: NativeTransitionConfig;
 }>;
 
 export interface NativeProps extends ViewProps {
@@ -43,6 +44,8 @@ export interface NativeProps extends ViewProps {
   animateRotateY?: CodegenTypes.WithDefault<CodegenTypes.Float, 0.0>;
   animateBorderRadius?: CodegenTypes.WithDefault<CodegenTypes.Float, 0.0>;
   animateBackgroundColor?: ColorValue;
+  animateBorderWidth?: CodegenTypes.WithDefault<CodegenTypes.Float, 0.0>;
+  animateBorderColor?: ColorValue;
 
   // Initial values for enter animations
   initialAnimateOpacity?: CodegenTypes.WithDefault<CodegenTypes.Float, 1.0>;
@@ -58,6 +61,8 @@ export interface NativeProps extends ViewProps {
     0.0
   >;
   initialAnimateBackgroundColor?: ColorValue;
+  initialAnimateBorderWidth?: CodegenTypes.WithDefault<CodegenTypes.Float, 0.0>;
+  initialAnimateBorderColor?: ColorValue;
 
   // Unified transition config — one struct with per-property configs
   transitions?: NativeTransitions;

--- a/src/__tests__/EaseView.test.tsx
+++ b/src/__tests__/EaseView.test.tsx
@@ -625,6 +625,119 @@ describe('EaseView', () => {
     });
   });
 
+  describe('animate borderWidth', () => {
+    it('passes borderWidth to native', () => {
+      render(<EaseView testID="ease" animate={{ borderWidth: 2 }} />);
+      expect(getNativeProps().animateBorderWidth).toBe(2);
+    });
+
+    it('defaults borderWidth to 0', () => {
+      render(<EaseView testID="ease" />);
+      expect(getNativeProps().animateBorderWidth).toBe(0);
+    });
+
+    it('sets bitmask for borderWidth (1 << 10 = 1024)', () => {
+      render(<EaseView testID="ease" animate={{ borderWidth: 2 }} />);
+      expect(getNativeProps().animatedProperties).toBe(1024);
+    });
+
+    it('passes initialAnimate borderWidth', () => {
+      render(
+        <EaseView
+          testID="ease"
+          initialAnimate={{ borderWidth: 0 }}
+          animate={{ borderWidth: 3 }}
+        />,
+      );
+      const props = getNativeProps();
+      expect(props.initialAnimateBorderWidth).toBe(0);
+      expect(props.animateBorderWidth).toBe(3);
+    });
+
+    it('strips style borderWidth when animate.borderWidth is set', () => {
+      const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      render(
+        <EaseView
+          testID="ease"
+          animate={{ borderWidth: 2 }}
+          style={{ borderWidth: 1, backgroundColor: 'red' }}
+        />,
+      );
+      const props = getNativeProps();
+      expect(props.style).toEqual(
+        expect.objectContaining({ backgroundColor: 'red' }),
+      );
+      expect(props.style.borderWidth).toBeUndefined();
+      spy.mockRestore();
+    });
+  });
+
+  describe('animate borderColor', () => {
+    it('passes borderColor as ColorValue', () => {
+      render(<EaseView testID="ease" animate={{ borderColor: 'red' }} />);
+      expect(getNativeProps().animateBorderColor).toBe('red');
+    });
+
+    it('defaults borderColor to black', () => {
+      render(<EaseView testID="ease" />);
+      expect(getNativeProps().animateBorderColor).toBe('black');
+    });
+
+    it('sets bitmask for borderColor (1 << 11 = 2048)', () => {
+      render(<EaseView testID="ease" animate={{ borderColor: 'blue' }} />);
+      expect(getNativeProps().animatedProperties).toBe(2048);
+    });
+
+    it('passes initialAnimate borderColor', () => {
+      render(
+        <EaseView
+          testID="ease"
+          initialAnimate={{ borderColor: 'blue' }}
+          animate={{ borderColor: 'red' }}
+        />,
+      );
+      const props = getNativeProps();
+      expect(props.initialAnimateBorderColor).toBe('blue');
+      expect(props.animateBorderColor).toBe('red');
+    });
+
+    it('strips style borderColor when animate.borderColor is set', () => {
+      const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      render(
+        <EaseView
+          testID="ease"
+          animate={{ borderColor: 'red' }}
+          style={{ borderColor: 'blue', backgroundColor: 'red' }}
+        />,
+      );
+      const props = getNativeProps();
+      expect(props.style).toEqual(
+        expect.objectContaining({ backgroundColor: 'red' }),
+      );
+      expect(props.style.borderColor).toBeUndefined();
+      spy.mockRestore();
+    });
+  });
+
+  describe('border transition category', () => {
+    it('passes border category in transition map', () => {
+      render(
+        <EaseView
+          testID="ease"
+          transition={{
+            default: { type: 'timing', duration: 300 },
+            border: { type: 'spring', damping: 20, stiffness: 200 },
+          }}
+        />,
+      );
+      const t = getNativeProps().transitions;
+      expect(t.border!.type).toBe('spring');
+      expect(t.border!.damping).toBe(20);
+      expect(t.border!.stiffness).toBe(200);
+      expect(t.defaultConfig.type).toBe('timing');
+    });
+  });
+
   describe('rotate loop props', () => {
     it('passes rotate 0→360 with loop repeat to native', () => {
       render(

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,8 @@ export type TransitionMap = {
   borderRadius?: SingleTransition;
   /** Config for backgroundColor. */
   backgroundColor?: SingleTransition;
+  /** Config for border properties (borderWidth, borderColor). */
+  border?: SingleTransition;
 };
 
 /** Animation transition configuration — either a single config or a per-property map. */
@@ -114,4 +116,8 @@ export type AnimateProps = {
   borderRadius?: number;
   /** Background color. Accepts any React Native color value. @default 'transparent' */
   backgroundColor?: ColorValue;
+  /** Border width in pixels. @default 0 */
+  borderWidth?: number;
+  /** Border color. Accepts any React Native color value. @default 'black' */
+  borderColor?: ColorValue;
 };


### PR DESCRIPTION
## Summary

EaseView can animate `borderRadius` and `backgroundColor` but not `borderWidth` or `borderColor`. This PR adds native animation support for both properties on both platforms.

On iOS, `layer.borderWidth` and `layer.borderColor` are standard animatable CALayer properties �� same pattern as the existing `cornerRadius` and `backgroundColor` animations. On Android, borders are rendered by React Native's `BorderDrawable` via `BackgroundStyleApplicator`, which provides public `setBorderWidth` and `setBorderColor` methods. `borderWidth` is animated via `ObjectAnimator` with a custom getter/setter that delegates to `BackgroundStyleApplicator.setBorderWidth`. `borderColor` uses `ValueAnimator.ofArgb` calling `BackgroundStyleApplicator.setBorderColor` each frame (same pattern as `backgroundColor`).

A new `border` transition category allows per-category animation config separate from `borderRadius`.

```tsx
<EaseView
  animate={{ borderWidth: 2, borderColor: 'red' }}
  transition={{ border: { type: 'spring', damping: 15 } }}
/>
```

## Test Plan

- `yarn format:write && yarn lint && yarn test` — all 65 tests pass, including 9 new tests covering borderWidth/borderColor prop resolution, bitmask flags, initialAnimate, and style conflict stripping.
- Native behavior should be verified by running the example app on iOS simulator and Android emulator.