### PR TITLE
fix(android): opacity not animating when combined with rotation

### DIFF
--- a/android/src/main/java/com/ease/EaseView.kt
+++ b/android/src/main/java/com/ease/EaseView.kt
@@ -446,8 +446,10 @@ class EaseView(context: Context) : ReactViewGroup(context) {
             }
 
             // Update backface visibility after setting initial rotation values.
+            // Skip when opacity is animated — backface check resets alpha.
             // https://github.com/facebook/react-native/blob/a98aa814/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt#L967-L985
-            if (mask and (MASK_ROTATE or MASK_ROTATE_X or MASK_ROTATE_Y) != 0) {
+            if (mask and (MASK_ROTATE or MASK_ROTATE_X or MASK_ROTATE_Y) != 0 &&
+                mask and MASK_OPACITY == 0) {
                 setBackfaceVisibilityDependantOpacity()
             }
         } else if (allTransitionsNone()) {
@@ -820,7 +822,10 @@ class EaseView(context: Context) : ReactViewGroup(context) {
 
         val batchId = animationBatchId
         pendingBatchAnimationCount++
-        val needsBackfaceUpdate = propertyName in isRotationProperty
+        // Only update backface visibility when opacity is NOT animated — the backface
+        // check resets alpha, which would clobber the animated opacity value.
+        val needsBackfaceUpdate = propertyName in isRotationProperty &&
+            (animatedProperties and MASK_OPACITY == 0)
 
         val animator = ObjectAnimator.ofFloat(this, propertyName, fromValue, toValue).apply {
             duration = config.duration.toLong()
@@ -880,9 +885,10 @@ class EaseView(context: Context) : ReactViewGroup(context) {
         val batchId = animationBatchId
         pendingBatchAnimationCount++
 
-        val needsBackfaceUpdate = viewProperty == DynamicAnimation.ROTATION ||
+        val needsBackfaceUpdate = (viewProperty == DynamicAnimation.ROTATION ||
             viewProperty == DynamicAnimation.ROTATION_X ||
-            viewProperty == DynamicAnimation.ROTATION_Y
+            viewProperty == DynamicAnimation.ROTATION_Y) &&
+            (animatedProperties and MASK_OPACITY == 0)
 
         val dampingRatio = (config.damping / (2.0f * sqrt(config.stiffness * config.mass)))
             .coerceAtLeast(0.01f)


### PR DESCRIPTION
## Summary

On Android, animating `opacity` and `rotate` (or `rotateX`/`rotateY`) simultaneously causes opacity to not animate — the view stays fully opaque.

**Root cause:** React Native's `ReactViewGroup.setBackfaceVisibilityDependantOpacity()` resets `alpha = backfaceOpacity` (1.0) every frame. EaseView calls this during rotation animations to handle backface visibility, but it overrides the animated opacity value.

**Fix:** Skip the backface alpha reset when `MASK_OPACITY` is in the animated bitmask. In that case, the opacity animator manages alpha directly. Applied to all three call sites: first-mount setup, timing animator, and spring animator.

## Test Plan

- `yarn lint && yarn test` — all 82 tests pass
- On Android: animate `opacity` and `rotate` simultaneously — opacity should now animate correctly
- On iOS: no change (was already working)