### PR TITLE
fix: preserve Android EaseView visuals on drop and add example

### DIFF
--- a/android/src/main/java/com/ease/EaseView.kt
+++ b/android/src/main/java/com/ease/EaseView.kt
@@ -691,7 +691,7 @@ class EaseView(context: Context) : ReactViewGroup(context) {
 
     private fun applyBackgroundColor(color: Int) {
         currentBackgroundColor = color
-        setBackgroundColor(color)
+        BackgroundStyleApplicator.setBackgroundColor(this, color)
     }
 
     private fun animateBackgroundColor(fromColor: Int, toColor: Int, config: TransitionConfig, loop: Boolean = false) {
@@ -714,8 +714,7 @@ class EaseView(context: Context) : ReactViewGroup(context) {
             }
             addUpdateListener { animation ->
                 val color = animation.animatedValue as Int
-                this@EaseView.currentBackgroundColor = color
-                this@EaseView.setBackgroundColor(color)
+                this@EaseView.applyBackgroundColor(color)
             }
             addListener(object : AnimatorListenerAdapter() {
                 private var cancelled = false
@@ -983,7 +982,7 @@ class EaseView(context: Context) : ReactViewGroup(context) {
         runningSpringAnimations.remove(viewProperty)
     }
 
-    fun cleanup() {
+    fun stopAnimations() {
         for (runnable in pendingDelayedRunnables) {
             removeCallbacks(runnable)
         }
@@ -1004,6 +1003,12 @@ class EaseView(context: Context) : ReactViewGroup(context) {
             setLayerType(savedLayerType, null)
         }
         activeAnimationCount = 0
+        pendingBatchAnimationCount = 0
+        anyInterrupted = false
+    }
+
+    fun cleanup() {
+        stopAnimations()
 
         prevOpacity = null
         prevTranslateX = null

--- a/android/src/main/java/com/ease/EaseViewManager.kt
+++ b/android/src/main/java/com/ease/EaseViewManager.kt
@@ -225,7 +225,15 @@ class EaseViewManager : ReactViewManager() {
 
     override fun onDropViewInstance(view: ReactViewGroup) {
         super.onDropViewInstance(view)
+        (view as? EaseView)?.stopAnimations()
+    }
+
+    override fun prepareToRecycleView(
+        reactContext: ThemedReactContext,
+        view: ReactViewGroup
+    ): ReactViewGroup? {
         (view as? EaseView)?.cleanup()
+        return super.prepareToRecycleView(reactContext, view)
     }
 
     override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {

--- a/android/src/main/java/com/ease/EaseViewManager.kt
+++ b/android/src/main/java/com/ease/EaseViewManager.kt
@@ -225,6 +225,8 @@ class EaseViewManager : ReactViewManager() {
 
     override fun onDropViewInstance(view: ReactViewGroup) {
         super.onDropViewInstance(view)
+        // Android screen transitions may keep drawing dropped views briefly.
+        // Stop animation work here, but keep visual state until recycle.
         (view as? EaseView)?.stopAnimations()
     }
 

--- a/example/app/issues/45/_layout.tsx
+++ b/example/app/issues/45/_layout.tsx
@@ -1,0 +1,29 @@
+import { Stack } from 'expo-router';
+
+export default function Issue45Layout() {
+  return (
+    <>
+      <Stack.Screen
+        options={{ title: 'Issue #45 — Android modal background' }}
+      />
+      <Stack
+        screenOptions={{
+          headerStyle: { backgroundColor: '#1a1a2e' },
+          headerTintColor: '#fff',
+          headerTitleStyle: { fontWeight: '700' },
+          contentStyle: { backgroundColor: '#1a1a2e' },
+        }}
+      >
+        <Stack.Screen name="index" options={{ title: 'Tab One' }} />
+        <Stack.Screen
+          name="modal"
+          options={{
+            animation: 'slide_from_right',
+            presentation: 'card',
+            title: 'Modal',
+          }}
+        />
+      </Stack>
+    </>
+  );
+}

--- a/example/app/issues/45/index.tsx
+++ b/example/app/issues/45/index.tsx
@@ -1,0 +1,70 @@
+import { useRouter } from 'expo-router';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+export default function Issue45Home() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  return (
+    <View style={[styles.root, { paddingTop: insets.top + 24 }]}>
+      <Text style={styles.heading}>Issue #45 Android modal background</Text>
+      <Text style={styles.body}>
+        Open the modal, then dismiss it with the back gesture or header back
+        button. The red animated card and green style card should keep their
+        backgrounds throughout the screen transition.
+      </Text>
+      <Text style={styles.link}>
+        https://github.com/AppAndFlow/react-native-ease/issues
+      </Text>
+
+      <Pressable
+        style={({ pressed }) => [styles.button, pressed && styles.buttonDown]}
+        onPress={() => router.push('/issues/45/modal')}
+      >
+        <Text style={styles.buttonText}>Open Modal</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+    paddingHorizontal: 20,
+  },
+  heading: {
+    color: '#fff',
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  body: {
+    color: '#aaaacc',
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 8,
+  },
+  link: {
+    color: '#6666aa',
+    fontSize: 12,
+    marginBottom: 28,
+  },
+  button: {
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    backgroundColor: '#4a90d9',
+    borderRadius: 8,
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+  },
+  buttonDown: {
+    backgroundColor: '#3978b8',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});

--- a/example/app/issues/45/modal.tsx
+++ b/example/app/issues/45/modal.tsx
@@ -1,0 +1,128 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { EaseView } from 'react-native-ease';
+
+export default function Issue45Modal() {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + 24 }]}>
+      <Text style={styles.heading}>Modal repro</Text>
+      <Text style={styles.body}>
+        Dismiss this screen. If the bug is present on Android, one or both card
+        backgrounds disappear during the closing transition while the blue child
+        remains visible. The animated card should freeze in its current frame
+        during the close transition.
+      </Text>
+
+      <View style={styles.cards}>
+        <View style={styles.demo}>
+          <Text style={styles.label}>Animated background</Text>
+          <EaseView
+            animate={{ backgroundColor: 'red' }}
+            transition={{ type: 'timing', duration: 300 }}
+            style={styles.card}
+          >
+            <View style={styles.child} />
+          </EaseView>
+        </View>
+
+        <View style={styles.demo}>
+          <Text style={styles.label}>Style background</Text>
+          <EaseView
+            transition={{ type: 'timing', duration: 300 }}
+            style={styles.card2}
+          >
+            <View style={styles.child} />
+          </EaseView>
+        </View>
+
+        <View style={styles.demo}>
+          <Text style={styles.label}>Active animation on close</Text>
+          <EaseView
+            initialAnimate={{ rotate: 0, scale: 0.85 }}
+            animate={{ rotate: 360, scale: 1.15 }}
+            transition={{
+              type: 'timing',
+              duration: 1200,
+              easing: 'linear',
+              loop: 'repeat',
+            }}
+            style={styles.spinCard}
+          >
+            <View style={styles.spinMarker} />
+          </EaseView>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    backgroundColor: '#1a1a2e',
+    gap: 16,
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+  },
+  heading: {
+    color: '#fff',
+    fontSize: 22,
+    fontWeight: '700',
+  },
+  body: {
+    color: '#aaaacc',
+    fontSize: 14,
+    lineHeight: 20,
+    maxWidth: 340,
+    textAlign: 'center',
+  },
+  cards: {
+    alignItems: 'center',
+    gap: 16,
+    marginTop: 12,
+  },
+  demo: {
+    alignItems: 'center',
+    gap: 8,
+  },
+  label: {
+    color: '#8888aa',
+    fontSize: 13,
+  },
+  card: {
+    alignItems: 'center',
+    height: 100,
+    justifyContent: 'center',
+    width: 100,
+  },
+  card2: {
+    alignItems: 'center',
+    backgroundColor: 'green',
+    height: 100,
+    justifyContent: 'center',
+    width: 100,
+  },
+  child: {
+    backgroundColor: 'blue',
+    height: 24,
+    width: 24,
+  },
+  spinCard: {
+    alignItems: 'center',
+    backgroundColor: '#4a90d9',
+    borderRadius: 12,
+    height: 100,
+    justifyContent: 'flex-start',
+    paddingTop: 10,
+    width: 100,
+  },
+  spinMarker: {
+    backgroundColor: '#fff',
+    borderRadius: 6,
+    height: 12,
+    width: 12,
+  },
+});

--- a/example/app/issues/45/modal.tsx
+++ b/example/app/issues/45/modal.tsx
@@ -11,8 +11,7 @@ export default function Issue45Modal() {
       <Text style={styles.body}>
         Dismiss this screen. If the bug is present on Android, one or both card
         backgrounds disappear during the closing transition while the blue child
-        remains visible. The animated card should freeze in its current frame
-        during the close transition.
+        remains visible.
       </Text>
 
       <View style={styles.cards}>
@@ -34,23 +33,6 @@ export default function Issue45Modal() {
             style={styles.card2}
           >
             <View style={styles.child} />
-          </EaseView>
-        </View>
-
-        <View style={styles.demo}>
-          <Text style={styles.label}>Active animation on close</Text>
-          <EaseView
-            initialAnimate={{ rotate: 0, scale: 0.85 }}
-            animate={{ rotate: 360, scale: 1.15 }}
-            transition={{
-              type: 'timing',
-              duration: 1200,
-              easing: 'linear',
-              loop: 'repeat',
-            }}
-            style={styles.spinCard}
-          >
-            <View style={styles.spinMarker} />
           </EaseView>
         </View>
       </View>
@@ -109,20 +91,5 @@ const styles = StyleSheet.create({
     backgroundColor: 'blue',
     height: 24,
     width: 24,
-  },
-  spinCard: {
-    alignItems: 'center',
-    backgroundColor: '#4a90d9',
-    borderRadius: 12,
-    height: 100,
-    justifyContent: 'flex-start',
-    paddingTop: 10,
-    width: 100,
-  },
-  spinMarker: {
-    backgroundColor: '#fff',
-    borderRadius: 6,
-    height: 12,
-    width: 12,
   },
 });

--- a/example/src/demos/index.ts
+++ b/example/src/demos/index.ts
@@ -142,6 +142,11 @@ export const demos: Record<string, DemoEntry> = {
     title: 'Issue #42 — Tabs loop',
     section: 'Issues',
   },
+  'issue-45': {
+    route: '/issues/45',
+    title: 'Issue #45 — Android modal background',
+    section: 'Issues',
+  },
 };
 
 interface SectionData {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes an Android issue where `EaseView` backgrounds could disappear during react-native-screens / Expo Router screen transitions after a view was dropped.

The problem was that Android called full `cleanup()` from `onDropViewInstance`, which reset visual properties like background color, transforms, opacity, borders, and elevation while the outgoing native view could still be visible during the transition. The fix splits lifecycle cleanup so dropping a view stops animation work without clearing its last rendered visual state, while full reset still happens when the view is prepared for recycling.

Also adds an Issue #45 repro screen to the example app to manually verify animated background, style background, and active animation behavior during navigation transitions.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Reproduced the bug with the code given in this issue. https://github.com/AppAndFlow/react-native-ease/issues/45

- Verified the Issue #45 repro manually on Android:
  - Opened `Issues` → `Issue #45 — Android modal background`
  - Opened the modal screen
  - Pressed back during the transition
  - Confirmed red animated background and green style background remain visible
  - Confirmed the active animation stops/freeze-frames during the close transition instead of disappearing or snapping/resetting
  
  

https://github.com/user-attachments/assets/296fd83c-9900-4d16-a64e-5c2be7d62d28



- Verified the same repro manually on iOS using the example app horizontal card transition.

- Ran:

```sh
yarn format:check
yarn lint
yarn test --runInBand
```
All checks passed.