### PR TITLE
chore: exclude example/dist from eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig([
     ignores: [
       'node_modules/',
       'lib/',
+      'example/dist/',
       'example/uniwind-types.d.ts',
       'example/src/uniwind-types.d.ts',
     ],


### PR DESCRIPTION
## Summary

Running `yarn lint` locally never finishes when `example/dist` (the example app's web export) exists: the eslint glob picks up the 2 MB minified `_expo/static/js/web/entry-*.js` bundle and the `prettier/prettier` rule grinds on it for 10+ minutes. CI is unaffected since it lints a clean checkout. This adds `example/dist/` to the flat-config ignores next to the other generated output (`lib/`).

## Test Plan

- With `example/dist` present locally, `yarn lint:eslint` used to hang for 10+ minutes; with this change it completes in ~7 s with no errors.
