### PR TITLE
chore(example): rename iOS project to EaseExample to avoid pod scheme collision

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ The [example app](/example/) demonstrates usage of the library. You need to run 
 
 It is configured to use the local version of the library, so any changes you make to the library's source code will be reflected in the example app. Changes to the library's JavaScript code will be reflected in the example app without a rebuild, but native code changes will require a rebuild of the example app.
 
-If you want to use Android Studio or Xcode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/Ease.xcworkspace` in Xcode and find the source files at `Pods > Development Pods > react-native-ease`.
+If you want to use Android Studio or Xcode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/EaseExample.xcworkspace` in Xcode and find the source files at `Pods > Development Pods > react-native-ease`.
 
 To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `react-native-ease` under `Android`.
 

--- a/example/app.json
+++ b/example/app.json
@@ -1,8 +1,8 @@
 {
-  "name": "Ease",
-  "displayName": "Ease",
+  "name": "EaseExample",
+  "displayName": "Ease Example",
   "expo": {
-    "name": "Ease",
+    "name": "Ease Example",
     "slug": "ease-example",
     "scheme": "ease-example",
     "version": "1.0.0",

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "web": "expo start --web",
     "prebuild": "expo prebuild",
     "build:android": "expo prebuild --platform android --clean && cd android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
-    "build:ios": "expo prebuild --platform ios --clean && xcodebuild -workspace ios/Ease.xcworkspace -scheme Ease -configuration Debug -sdk iphonesimulator -arch x86_64 build"
+    "build:ios": "expo prebuild --platform ios --clean && xcodebuild -workspace ios/EaseExample.xcworkspace -scheme EaseExample -configuration Debug -sdk iphonesimulator -arch x86_64 build"
   },
   "dependencies": {
     "@expo/metro-runtime": "~55.0.6",


### PR DESCRIPTION
## Summary

`expo run:ios` for the example app intermittently "succeeds" without producing an app: it builds only the `Ease` static library, then dies with `ENOENT ... RCTSwiftUI.app/Info.plist` when expo-cli goes looking for the binary. The cause is a name collision: the app project generated from `expo.name` was `Ease`, the same as the development pod, and CocoaPods recreates a user scheme for every pod target on each `pod install` — so `xcodebuild -scheme Ease` on the workspace can resolve to the pod's scheme instead of the app's. Deleting `Pods/Pods.xcodeproj/xcuserdata/*/xcschemes/Ease.xcscheme` worked around it, but the scheme comes back on the next `pod install`.

This renames the example app to `expo.name: "Ease Example"` so prebuild generates `EaseExample.xcodeproj`/`EaseExample` scheme, which can't collide. The bundle id (`com.janic.easeexample`) is unchanged; the home-screen label becomes "Ease Example". `example/ios` is gitignored prebuild output, so the only other changes are the `build:ios` script and a CONTRIBUTING.md path.

## Test Plan

- `expo prebuild --platform ios --clean` regenerates `EaseExample.xcworkspace`; the fresh `pod install` recreates the pod's `Ease.xcscheme` user scheme as always.
- With that pod scheme present (not deleted), `expo run:ios` now builds the app target, installs `EaseExample.app` on the simulator, and the app launches and renders the demo list normally. Before the rename this exact state failed as described above.
