### PR TITLE
chore: run unit tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,19 @@ jobs:
       - name: Check lint
         run: yarn lint
 
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Run unit tests
+        run: yarn test
+
   build-library:
     runs-on: ubuntu-latest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ The [example app](/example/) demonstrates usage of the library. You need to run 
 
 It is configured to use the local version of the library, so any changes you make to the library's source code will be reflected in the example app. Changes to the library's JavaScript code will be reflected in the example app without a rebuild, but native code changes will require a rebuild of the example app.
 
-If you want to use Android Studio or Xcode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/Ease.xcworkspace` in Xcode and find the source files at `Pods > Development Pods > react-native-ease`.
+If you want to use Android Studio or Xcode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/EaseExample.xcworkspace` in Xcode and find the source files at `Pods > Development Pods > react-native-ease`.
 
 To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `react-native-ease` under `Android`.
 

--- a/example/app.json
+++ b/example/app.json
@@ -1,8 +1,8 @@
 {
-  "name": "Ease",
-  "displayName": "Ease",
+  "name": "EaseExample",
+  "displayName": "Ease Example",
   "expo": {
-    "name": "Ease",
+    "name": "Ease Example",
     "slug": "ease-example",
     "scheme": "ease-example",
     "version": "1.0.0",

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "web": "expo start --web",
     "prebuild": "expo prebuild",
     "build:android": "expo prebuild --platform android --clean && cd android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
-    "build:ios": "expo prebuild --platform ios --clean && xcodebuild -workspace ios/Ease.xcworkspace -scheme Ease -configuration Debug -sdk iphonesimulator -arch x86_64 build"
+    "build:ios": "expo prebuild --platform ios --clean && xcodebuild -workspace ios/EaseExample.xcworkspace -scheme EaseExample -configuration Debug -sdk iphonesimulator -arch x86_64 build"
   },
   "dependencies": {
     "@expo/metro-runtime": "~55.0.6",


### PR DESCRIPTION
## Summary

CI had lint and build jobs but never ran the Jest suite, so the prop-resolution tests in `src/__tests__/` (~1000 lines) gated nothing — a regression in the JS layer would ship silently. This adds a `test` job mirroring the existing `lint` job.

## Test Plan

`yarn test` passes locally (3 suites, 82 tests). This PR's own CI run demonstrates the new job working.